### PR TITLE
Add graphql and graphiql

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,3 @@
+class ApiController < ActionController::Base
+  protect_from_forgery with: :null_session
+end

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,0 +1,19 @@
+class GraphqlController < ApiController
+  def query
+    query_variables = ensure_hash(params[:variables])
+    result = AppSchema.execute(params[:query], variables: query_variables)
+    render json: result
+  end
+
+  private
+
+  def ensure_hash(query_variables)
+    if query_variables.blank?
+      {}
+    elsif query_variables.is_a?(String)
+      JSON.parse(query_variables)
+    else
+      query_variables
+    end
+  end
+end

--- a/app/graph/app_schema.rb
+++ b/app/graph/app_schema.rb
@@ -1,0 +1,3 @@
+AppSchema = GraphQL::Schema.define do
+  query QueryType
+end

--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -1,0 +1,6 @@
+QueryType = GraphQL::ObjectType.define do
+  name 'Query'
+  description 'The query root for this schema'
+
+  field :simple, !types.String, resolve: -> (_, args, _) { SecureRandom.uuid }
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,8 +11,7 @@ module Webscale
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    config.autoload_paths << Rails.root.join('app', 'graph')
+    config.autoload_paths << Rails.root.join('app', 'graph', 'types')
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  post '/graphql', to: 'graphql#query'
+  mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: '/graphql'
 end


### PR DESCRIPTION
This PR just adds GraphQL and GraphiQL to webscale. A follow up PR will be set up after the migrations are merged to add the appropriate types and relations.

#### 🎩 :
 1. Run the `rails server`
1. Visit `http://localhost:3000/graphiql`
1. Try out a query

#### Sample Query
```graphql
query {
  simple
}
```