### PR TITLE
[REST] Add likes controller and spec

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,38 @@
+class LikesController < ApiController
+  before_action :set_like, only: [:destroy]
+
+  # GET /likes
+  def index
+    likes = Like.all
+    render :json => likes.to_json
+  end
+
+  # POST /likes
+  def create
+    content = like_params[:content_type].constantize.find(like_params[:content_id])
+    like = content.likes.new(like_params)
+    if like.save!
+      render :json => like.to_json, status: :created
+    else
+      render :json => like.errors, status: :unprocessable_entity
+    end
+  rescue NoMethodError, NameError, ActiveRecord::RecordNotFound
+    head :unprocessable_entity
+  end
+
+  # DELETE /likes/1
+  def destroy
+    @like.destroy
+    render json: 'Like was successfully destroyed.', status: :ok
+  end
+
+  private
+
+  def set_like
+    @like = Like.find(params[:id])
+  end
+
+  def like_params
+    params.permit(:user_id, :content_id, :content_type)
+  end
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :author, class_name: 'User'
   belongs_to :content, polymorphic: true
+
+  has_many :likes, as: :content
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -2,4 +2,5 @@ class Photo < ApplicationRecord
   belongs_to :post
 
   has_many :comments, as: :content
+  has_many :likes, as: :content
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,4 +3,5 @@ class Post < ApplicationRecord
   belongs_to :receiver, class_name: 'User'
 
   has_many :comments, as: :content
+  has_many :likes, as: :content
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
   resources :posts
   resources :photos
   resources :comments
+  resources :likes, except: [:show, :update, :edit]
 end

--- a/db/migrate/20170923230214_create_likes.rb
+++ b/db/migrate/20170923230214_create_likes.rb
@@ -1,6 +1,6 @@
 class CreateLikes < ActiveRecord::Migration[5.1]
   def change
-    create_table :likes, id: false do |t|
+    create_table :likes do |t|
       t.references :user, null: false
       t.references :content, null: false, polymorphic: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,14 +16,14 @@ ActiveRecord::Schema.define(version: 20170923230250) do
     t.text "body"
     t.bigint "author_id", null: false
     t.string "content_type", null: false
-    t.integer "content_id", null: false
+    t.bigint "content_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["author_id"], name: "index_comments_on_author_id"
     t.index ["content_type", "content_id"], name: "index_comments_on_content_type_and_content_id"
   end
 
-  create_table "likes", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "likes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.bigint "user_id", null: false
     t.string "content_type", null: false
     t.bigint "content_id", null: false

--- a/spec/controllers/likes_controller_spec.rb
+++ b/spec/controllers/likes_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe LikesController, type: :controller do
+  describe "GET index" do
+    context 'initialized with content type post' do
+      let(:user) { create(:user) }
+      let(:post) { create(:post) }
+      let(:like) { create(:post_like, user: user, content: post) }
+
+      it "renders the likes index" do
+        get :index
+        expect(response.status).to eq 200
+      end
+    end
+  end
+
+  describe "POST create" do
+    context 'with existing user and post' do
+      let(:user) { create(:user) }
+      let(:like_post) { create(:post) }
+
+      it "responds with the commment when create is successful" do
+        post :create, params: {
+          user_id: user.id,
+          content_id: like_post.id,
+          content_type: 'Post'
+        }
+        expect(response.status).to eq 201
+      end
+
+      it "responds with 422 when the content does not exist" do
+        post :create, params: {
+          user_id: user.id,
+          content_id: 0,
+          content_type: 'Post'
+        }
+        expect(response.status).to eq 422
+      end
+
+      it "responds with 422 when the content does not exist" do
+        post :create, params: {
+          user_id: user.id,
+          content_id: like_post.id,
+          content_type: 'Something'
+        }
+        expect(response.status).to eq 422
+      end
+    end
+  end
+
+  describe "DELETE destroy" do
+    context 'with existing like' do
+      let(:user) { create(:user) }
+      let(:post) { create(:post) }
+      let(:like) { create(:post_like, user: user, content: post) }
+
+      it "responds with ok when destroy is successful" do
+        delete :destroy, params: {
+          id: like.id
+        }
+        expect(response.status).to eq 200
+      end
+    end
+  end
+end


### PR DESCRIPTION
Note, this also removes `id:false` from the `likes` table, since that was causing some issues with `ActiveRecord#destroy`.
If that was for uniqueness purposes, let's use validations on the model instead of database constraints.
