### PR TITLE
Implement relay node interface

### DIFF
--- a/app/graph/app_schema.rb
+++ b/app/graph/app_schema.rb
@@ -2,5 +2,12 @@ AppSchema = GraphQL::Schema.define do
   query QueryType
 
   id_from_object ->(object, _, _) { object.to_global_id.to_s }
-  resolve_type -> (type, obj, _ctx) { type.possible_types.detect { |t| t.name == obj.class.name } }
+  object_from_id -> (id, _ctx) { GlobalID::Locator.locate(id) }
+  resolve_type -> (type, obj, _ctx) do
+    if type.respond_to?(:possible_types)
+      type.possible_types.detect { |t| t.name == obj.class.name }
+    else
+      "#{obj.class}Type".constantize
+    end
+  end
 end

--- a/app/graph/app_schema.rb
+++ b/app/graph/app_schema.rb
@@ -2,7 +2,7 @@ AppSchema = GraphQL::Schema.define do
   query QueryType
 
   id_from_object ->(object, _, _) { object.to_global_id.to_s }
-  object_from_id -> (id, _ctx) { GlobalID::Locator.locate(id) }
+  object_from_id -> (id, _ctx) { ActiveRecordResolver.call(nil, { id: id }, nil) }
   resolve_type -> (type, obj, _ctx) do
     if type.respond_to?(:possible_types)
       type.possible_types.detect { |t| t.name == obj.class.name }

--- a/app/graph/resolvers/active_record_resolver.rb
+++ b/app/graph/resolvers/active_record_resolver.rb
@@ -1,5 +1,7 @@
 module ActiveRecordResolver
   def self.call(_, args, _)
     GlobalID::Locator.locate(args[:id])
+  rescue ActiveRecord::RecordNotFound
+    nil
   end
 end

--- a/app/graph/types/comment_type.rb
+++ b/app/graph/types/comment_type.rb
@@ -1,6 +1,9 @@
 CommentType = GraphQL::ObjectType.define do
   name 'Comment'
   description 'A comment a user left on some content.'
+
+  implements GraphQL::Relay::Node.interface
+
   global_id_field :id
 
   field :body, !types.String

--- a/app/graph/types/photo_type.rb
+++ b/app/graph/types/photo_type.rb
@@ -1,6 +1,9 @@
 PhotoType = GraphQL::ObjectType.define do
   name 'Photo'
   description 'A photo uploaded by a user'
+
+  implements GraphQL::Relay::Node.interface
+
   global_id_field :id
 
   field :post, !PostType

--- a/app/graph/types/post_type.rb
+++ b/app/graph/types/post_type.rb
@@ -1,6 +1,9 @@
 PostType = GraphQL::ObjectType.define do
   name 'Post'
   description 'A post made by a user'
+
+  implements GraphQL::Relay::Node.interface
+
   global_id_field :id
 
   field :body, !types.String

--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -4,21 +4,8 @@ QueryType = GraphQL::ObjectType.define do
 
   field :simple, !types.String, resolve: -> (_, args, _) { SecureRandom.uuid }
 
-  field :post, PostType, resolve: ActiveRecordResolver do
-    argument :id, !types.ID
-  end
-
-  field :photo, PhotoType, resolve: ActiveRecordResolver do
-    argument :id, !types.ID
-  end
-
-  field :comment, CommentType, resolve: ActiveRecordResolver do
-    argument :id, !types.ID
-  end
-
-  field :user, UserType, resolve: ActiveRecordResolver do
-    argument :id, !types.ID
-  end
+  field :node, GraphQL::Relay::Node.field
+  field :nodes, GraphQL::Relay::Node.plural_field
 
   field :like, LikeType do
     argument :user_id, !types.ID

--- a/app/graph/types/user_type.rb
+++ b/app/graph/types/user_type.rb
@@ -1,6 +1,9 @@
 UserType = GraphQL::ObjectType.define do
   name 'User'
   description 'A user'
+
+  implements GraphQL::Relay::Node.interface
+
   global_id_field :id
 
   field :first_name, !types.String


### PR DESCRIPTION
This will replace a lot of the top level fields on the QueryRoot with node. It'll infer the type from the gid.

```graphql
{
  node(id: "gid://webscale/User/1") {
    id
    ...on User {
      first_name
    }
  }
  nodes(ids: ["gid://webscale/User/1", "gid://webscale/Post/2"]) {
    __typename
  }
}
```