### PR TITLE
Add a ES backed search field in graphql

### DIFF
--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -7,6 +7,18 @@ QueryType = GraphQL::ObjectType.define do
   field :node, GraphQL::Relay::Node.field
   field :nodes, GraphQL::Relay::Node.plural_field
 
+  field :search, types[!SearchResultType] do
+    argument :query, !types.String
+
+    resolve -> (_, args, _) do
+      response = Elasticsearch::Model.search(
+        args[:query],
+        SearchRecordType.possible_types.map(&:name).map(&:constantize)
+      )
+      response.results.to_a.map(&:to_hash)
+    end
+  end
+
   field :like, LikeType do
     argument :user_id, !types.ID
     argument :content_id, !types.ID

--- a/app/graph/types/search_record_type.rb
+++ b/app/graph/types/search_record_type.rb
@@ -1,0 +1,5 @@
+SearchRecordType = GraphQL::UnionType.define do
+  name 'SearchResultUnionType'
+  description 'A searchable type.'
+  possible_types [PostType, CommentType]
+end

--- a/app/graph/types/search_result_type.rb
+++ b/app/graph/types/search_result_type.rb
@@ -1,0 +1,13 @@
+SearchResultType = GraphQL::ObjectType.define do
+  name 'SearchResultType'
+  description 'A search result.'
+
+  field :index, !types.String, resolve: -> (obj, _, _) { obj['_index'] }
+  field :type, !types.String, resolve: -> (obj, _, _) { obj['_type'] }
+  field :id, !types.String, resolve: -> (obj, _, _) { obj['_id'] }
+  field :score, !types.Float, resolve: -> (obj, _, _) { obj['_score'] }
+
+  field :record, !SearchRecordType, resolve: -> (obj, _, _) do
+    obj['_type'].camelize.constantize.new(obj['_source'])
+  end
+end


### PR DESCRIPTION

To 🎩 : 
1. setup ElasticSearch (check README)
1. run the following query

```graphql
{
  search(query: "Televizzle") {
    id
    score
    index
    type
    record {
      __typename
    }
  }
}
```

You should get a result like the following.

```json
{
  "data": {
    "search": [
      {
        "id": "3",
        "score": 2.4414725,
        "index": "comments",
        "type": "comment",
        "record": {
          "__typename": "Comment"
        }
      }
    ]
  }
}
```