### PR TITLE
Enable elastic search query analysis

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     graphql (1.7.13)
-    graphql-analyzer (0.1.2)
+    graphql-analyzer (0.1.3)
       graphql (>= 0.8, < 2)
     hashie (3.5.7)
     i18n (0.9.5)

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -16,7 +16,12 @@ class GraphqlController < ApiController
   end
 
   def analyze_schema
-    @analyze_schema ||= AppSchema.redefine { use GraphQL::Analyzer.new([GraphQL::Analyzer::Instrumentation::Mysql.new]) }
+    @analyze_schema ||= AppSchema.redefine do
+      use GraphQL::Analyzer.new([
+        GraphQL::Analyzer::Instrumentation::Mysql.new,
+        GraphQL::Analyzer::Instrumentation::ElasticSearch.new
+      ])
+    end
   end
 
   def ensure_hash(query_variables)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,5 +1,6 @@
 class Comment < ApplicationRecord
   include Elasticsearch::Model
+  include Elasticsearch::Model::Callbacks unless Rails.env.test?
 
   belongs_to :author, class_name: 'User'
   belongs_to :content, polymorphic: true

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,6 @@
 class Post < ApplicationRecord
   include Elasticsearch::Model
+  include Elasticsearch::Model::Callbacks unless Rails.env.test?
 
   belongs_to :author, class_name: 'User'
   belongs_to :receiver, class_name: 'User'

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require 'elasticsearch/rails/instrumentation'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+Elasticsearch::Model.client = Elasticsearch::Client.new url: ENV['BONSAI_URL']
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 


### PR DESCRIPTION
Opps, I accidentally merged #49 before it was ready via the command line, I reverted and opened this PR.

Add ES instrumentation from https://github.com/GraphQL-Query-Planner/graphql-analyzer/pull/9

Make sure to setup elastic search, the setup instructions are in the readme
https://github.com/GraphQL-Query-Planner/webscale#elasticsearch-setup

Query
```graphql
query {
  search(query: "Televizzle") {
    id
    score
    index
    type
    record {
      __typename
    }
  }
}
```

Results
```json
{
            "path": [
              "s1"
            ],
            "adapter": "elasticsearch",
            "parentType": "Query",
            "fieldName": "search",
            "returnType": "[SearchResultType!]",
            "details": [
              {
                "name": "search.elasticsearch",
                "start": "2018-03-13T22:00:28.741-04:00",
                "finish": "2018-03-13T22:00:28.751-04:00",
                "id": "030a3d2c8dfb36b671d2",
                "payload": {
                  "name": "Search",
                  "klass": "#<Elasticsearch::Model::Multimodel:0x007fb0e203f3a0>",
                  "search": {
                    "index": [
                      "posts",
                      "comments"
                    ],
                    "type": [
                      "post",
                      "comment"
                    ],
                    "q": "Televizzle"
                  }
                }
              }
            ]
          }
}
```