### PR TITLE
Update query type to support some example queries

### DIFF
--- a/QueryExamples.md
+++ b/QueryExamples.md
@@ -1,0 +1,115 @@
+#### Query examples
+
+These queries show examples of problems (or non-problems) that can be identified with the graphql-analyzer.
+**Note: id values will need to be changed**
+
+### N+1
+**Description**
+Select the first ten posts on a user's wall, and get:
+- post -> body
+- author -> first name
+- author -> last name
+
+```
+{
+  posts(first: 10, receiver_id: 1) {
+    edges {
+      node {
+        id
+        author {
+          id
+          first_name
+          last_name
+        }
+        body
+      }
+    }
+  }
+}
+```
+
+### Indexed
+**Description**
+Select the comments for a specific post
+
+```
+{
+  comments(content_id: 1, content_type: "Post") {
+    edges{
+      node {
+        id
+      }
+    }
+  }
+}
+```
+
+### Non-Indexed (Full Table Scan)
+**Description**
+Perhaps we add to the GraphQL schema the ability to query for all the users with a certain first name.
+If we forget to add an index on the `users` table for `first_name`, we'll get a full table scan.
+
+```
+{
+  users(first_name: "Darrel") {
+    edges{
+      node {
+        id
+        first_name
+        last_name
+        email
+      }
+    }
+  }
+}
+```
+The query above does a full table scan
+
+This query below which searches on last name will only search 1 row, since last_name is indexed.
+```
+{
+  users(last_name: "Kunde") {
+    edges{
+      node {
+        id
+        first_name
+        last_name
+        email
+      }
+    }
+  }
+}
+```
+
+### Indexed with additional filtering
+**Description**
+Select posts for a specific receiver within a certain range of IDs.
+```
+{
+  posts(receiver_id: 1, min_id: 1, max_id: 500) {
+    edges{
+      node {
+        id
+      }
+    }
+  }
+}
+```
+
+### Unoptimal index
+**Description**
+Find a like on a specific post by a specific user
+```
+{
+  likes(content_id: 11, content_type: "Post", user_id: 2) {
+    edges{
+      node {
+        id
+        user {
+          id
+        }
+      }
+    }
+  }
+}
+```

--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -20,14 +20,15 @@ QueryType = GraphQL::ObjectType.define do
   end
 
   connection :posts, PostType.connection_type do
+    argument :max_id, types.ID
+    argument :min_id, types.ID
     argument :receiver_id, types.ID
 
     resolve -> (_, args, _) {
-      if args[:receiver_id]
-        Post.where(receiver_id: args[:receiver_id])
-      else
-        Post.all
-      end
+      id_cond = args[:min_id] && [:max_id] ? { id: args[:min_id]..args[:max_id] } : nil
+      receiver_cond = args[:receiver_id] ? { receiver_id: args[:receiver_id] } : nil
+
+      Post.where(receiver_cond).where(id_cond)
     }
   end
 
@@ -38,8 +39,27 @@ QueryType = GraphQL::ObjectType.define do
     resolve -> (_, args, _) { Comment.where(content_id: args[:content_id], content_type: args[:content_type]) }
   end
 
+  connection :likes, LikeType.connection_type do
+    argument :content_id, !types.ID
+    argument :content_type, !types.ID
+    argument :user_id, types.ID
+
+    resolve -> (_, args, _) {
+      user_cond = args[:user_id] ? { user_id: args[:user_id] } : nil
+      Like.ignore_index("index_likes_on_user_id_and_content_id_and_content_type").where(user_cond).where(content_id: args[:content_id], content_type: args[:content_type])
+    }
+  end
+
   connection :users, UserType.connection_type do
-    resolve -> (_, args, _) { User.all }
+    argument :first_name, types.String
+    argument :last_name, types.String
+
+    resolve -> (_, args, _) {
+      first_name_cond = args[:first_name] ? {first_name: args[:first_name]} : nil
+      last_name_cond = args[:last_name] ? {last_name: args[:last_name]} : nil
+
+      User.where(first_name_cond).where(last_name_cond)
+    }
   end
 
   field :like, LikeType do

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,4 +1,8 @@
 class Like < ApplicationRecord
   belongs_to :user
   belongs_to :content, polymorphic: true
+
+  def self.ignore_index(index)
+    from("#{self.table_name} IGNORE INDEX(#{index})")
+  end
 end


### PR DESCRIPTION
This updates the GraphQL schema to support certain types of queries that we can demo with the analyzer.

New ones include: 
- Indexed with additional filtering
  - uses the `posts` connection
- Non-optimal index
  - uses the `likes` connection
- Indexed/Non-index
  - uses the `users` connection

N+1 was already possible