### PR TITLE
Fix resolvers for connections by using GIDs

### DIFF
--- a/QueryExamples.md
+++ b/QueryExamples.md
@@ -12,7 +12,7 @@ Select the first ten posts on a user's wall, and get:
 
 ```
 {
-  posts(first: 10, receiver_id: 1) {
+  posts(first: 10, receiver_id: "gid://webscale/User/1") {
     edges {
       node {
         id
@@ -34,7 +34,7 @@ Select the comments for a specific post
 
 ```
 {
-  comments(content_id: 1, content_type: "Post") {
+  comments(content_id: "gid://webscale/Post/1", content_type: "Post") {
     edges{
       node {
         id
@@ -51,7 +51,7 @@ If we forget to add an index on the `users` table for `first_name`, we'll get a 
 
 ```
 {
-  users(first_name: "Darrel") {
+  users(first_name: "Roderick") {
     edges{
       node {
         id
@@ -68,7 +68,7 @@ The query above does a full table scan
 This query below which searches on last name will only search 1 row, since last_name is indexed.
 ```
 {
-  users(last_name: "Kunde") {
+  users(last_name: "Hane") {
     edges{
       node {
         id
@@ -86,7 +86,7 @@ This query below which searches on last name will only search 1 row, since last_
 Select posts for a specific receiver within a certain range of IDs.
 ```
 {
-  posts(receiver_id: 1, min_id: 1, max_id: 500) {
+  posts(receiver_id: "gid://webscale/User/1", min_id: 1, max_id: 500) {
     edges{
       node {
         id
@@ -101,7 +101,7 @@ Select posts for a specific receiver within a certain range of IDs.
 Find a like on a specific post by a specific user
 ```
 {
-  likes(content_id: 11, content_type: "Post", user_id: 2) {
+  likes(content_id: "gid://webscale/Post/11", content_type: "Post", user_id: "gid://webscale/User/2") {
     edges{
       node {
         id

--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -44,7 +44,7 @@ QueryType = GraphQL::ObjectType.define do
 
   connection :comments, CommentType.connection_type do
     argument :content_id, !types.ID
-    argument :content_type, !types.ID
+    argument :content_type, !types.String
 
     resolve -> (_, args, _) {
       content_id = GlobalID::Locator.locate(args[:content_id]).id
@@ -54,7 +54,7 @@ QueryType = GraphQL::ObjectType.define do
 
   connection :likes, LikeType.connection_type do
     argument :content_id, !types.ID
-    argument :content_type, !types.ID
+    argument :content_type, !types.String
     argument :user_id, types.ID
 
     resolve -> (_, args, _) {

--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -25,10 +25,20 @@ QueryType = GraphQL::ObjectType.define do
     argument :receiver_id, types.ID
 
     resolve -> (_, args, _) {
-      id_cond = args[:min_id] && [:max_id] ? { id: args[:min_id]..args[:max_id] } : nil
-      receiver_cond = args[:receiver_id] ? { receiver_id: args[:receiver_id] } : nil
+      if args[:min_id] && [:max_id]
+        id_range_condition = { id: args[:min_id]..args[:max_id] }
+      else
+        id_range_condition = nil
+      end
 
-      Post.where(receiver_cond).where(id_cond)
+      if args[:receiver_id]
+        receiver_id = GlobalID::Locator.locate(args[:receiver_id]).id
+        receiver_condition = { receiver_id: receiver_id }
+      else
+        receiver_condition = nil
+      end
+
+      Post.where(receiver_condition).where(id_range_condition)
     }
   end
 
@@ -36,7 +46,10 @@ QueryType = GraphQL::ObjectType.define do
     argument :content_id, !types.ID
     argument :content_type, !types.ID
 
-    resolve -> (_, args, _) { Comment.where(content_id: args[:content_id], content_type: args[:content_type]) }
+    resolve -> (_, args, _) {
+      content_id = GlobalID::Locator.locate(args[:content_id]).id
+      Comment.where(content_id: content_id, content_type: args[:content_type])
+    }
   end
 
   connection :likes, LikeType.connection_type do
@@ -45,8 +58,15 @@ QueryType = GraphQL::ObjectType.define do
     argument :user_id, types.ID
 
     resolve -> (_, args, _) {
-      user_cond = args[:user_id] ? { user_id: args[:user_id] } : nil
-      Like.ignore_index("index_likes_on_user_id_and_content_id_and_content_type").where(user_cond).where(content_id: args[:content_id], content_type: args[:content_type])
+      content_id = GlobalID::Locator.locate(args[:content_id]).id
+
+      if args[:user_id]
+        user_id = GlobalID::Locator.locate(args[:user_id]).id
+        user_condition = { user_id: user_id }
+      else
+        user_condition = nil
+      end
+      Like.ignore_index("index_likes_on_user_id_and_content_id_and_content_type").where(user_condition).where(content_id: content_id, content_type: args[:content_type])
     }
   end
 
@@ -55,10 +75,10 @@ QueryType = GraphQL::ObjectType.define do
     argument :last_name, types.String
 
     resolve -> (_, args, _) {
-      first_name_cond = args[:first_name] ? {first_name: args[:first_name]} : nil
-      last_name_cond = args[:last_name] ? {last_name: args[:last_name]} : nil
+      first_name_condition = args[:first_name] ? {first_name: args[:first_name]} : nil
+      last_name_condition = args[:last_name] ? {last_name: args[:last_name]} : nil
 
-      User.where(first_name_cond).where(last_name_cond)
+      User.where(first_name_condition).where(last_name_condition)
     }
   end
 
@@ -66,6 +86,10 @@ QueryType = GraphQL::ObjectType.define do
     argument :user_id, !types.ID
     argument :content_id, !types.ID
 
-    resolve -> (_, args, _) { Like.find_by(user_id: args[:user_id], content_id: args[:content_id]) }
+    resolve -> (_, args, _) {
+      user_id = GlobalID::Locator.locate(args[:user_id]).id
+      content_id = GlobalID::Locator.locate(args[:content_id]).id
+      Like.find_by(user_id: user_id, content_id: content_id)
+    }
   end
 end

--- a/spec/graph/comment_spec.rb
+++ b/spec/graph/comment_spec.rb
@@ -3,12 +3,16 @@ require 'explainer/parser'
 
 describe Comment, type: :model do
   let!(:post) { create(:post) }
+  let!(:posts) { FactoryGirl.create_list(:post, 100) }
   let!(:post_comments) { FactoryGirl.create_list(:post_comment, 5, content: post) }
+  let!(:post_comments2) { FactoryGirl.create_list(:post_comment, 50) }
+  let!(:photo_comments) { FactoryGirl.create_list(:photo_comment, 100, content: post) }
+  # need the extras so that index is used
 
-  it "should not use index for content_type of comment" do
+  it "should use index for content_type of comment" do
     query_string = %|
       {
-        comments(content_id: #{post.id}, content_type: "Post") {
+        comments(content_id: "gid://webscale/Post/#{post.id}", content_type: "Post") {
           edges{
             node {
               id
@@ -25,9 +29,10 @@ describe Comment, type: :model do
       explain_output = ActiveRecord::Base.exec_explain([query])
       result = Explainer::Parser.parse(explain_output)
     end
-    explained_query = results.first.explained_queries.first
+    explained_query = results.last.explained_queries.first
 
-    expect(explained_query).not_to be_indexed
-    expect(explained_query).to be_full_table_scan
+    expect(explained_query).not_to be_full_table_scan
+    expect(explained_query).to be_indexed
+
   end
 end


### PR DESCRIPTION
Since connections return `gid`s by default, we should also be expecting
these as arguments from the client, rather than integer value `id`s.